### PR TITLE
Remove deprecated rails behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tmp/pids/*.pid
 
 # Ignore temporary cache files
 tmp/cache/
+
+# Ignore public assets
+public/assets/

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '5.2'
 # Use postgresql as the database for Active Record
-gem 'pg', '~> 0.18'
+gem 'pg'
 # Use Puma as the app server
 gem 'puma', '~> 3.12'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,7 @@ GEM
     nio4r (2.7.4)
     nokogiri (1.13.10-x64-mingw32)
       racc (~> 1.4)
-    pg (0.21.0)
+    pg (1.5.9-x64-mingw32)
     puma (3.12.6)
     racc (1.8.1)
     rack (2.2.11)
@@ -201,7 +201,7 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mimemagic!
-  pg (~> 0.18)
+  pg
   puma (~> 3.12)
   rails (= 5.2)
   rails_12factor
@@ -217,4 +217,4 @@ RUBY VERSION
    ruby 2.6.6p146
 
 BUNDLED WITH
-   2.4.22
+   2.2.3

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -18,7 +18,7 @@ ActiveSupport.to_time_preserves_timezone = true
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
+# ActiveSupport.halt_callback_chains_on_return_false = false
 
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
Updated pg gem

We should be able to successfully run
` ruby -S bundle exec rake assets:precompile`

Which failed during the deployment [here](https://railway.com/project/d7292fa6-8028-434e-842f-6dfa2886eb2f/service/a603aa71-8398-43a3-93c3-0546944d53a5?context=2025-02-22T06%3A57%3A03.452455978Z&environmentId=3cb9e681-e7c8-4a53-9f0d-e91d21277020&id=9ade4716-37b9-4ee4-9c3d-a6b66d086aa2&forceViewAll=true)

![image](https://github.com/user-attachments/assets/25c54068-a57a-4398-ba60-0b3af56832ac)
